### PR TITLE
Fix label <> type for user attribute

### DIFF
--- a/pkg/looker/resource_user_attribute.go
+++ b/pkg/looker/resource_user_attribute.go
@@ -85,7 +85,7 @@ func resourceUserAttributeUpdate(d *schema.ResourceData, m interface{}) error {
 
 	userAttributeName := d.Get("name").(string)
 	userAttributeType := d.Get("type").(string)
-	userAttributeLabel := d.Get("type").(string)
+	userAttributeLabel := d.Get("label").(string)
 
 	writeUserAttribute := apiclient.WriteUserAttribute{
 		Name:  userAttributeName,


### PR DESCRIPTION
My latest plan wants to create all the user attributes that already exist. I'm not actually sure if terraform can identify that these resources already exist if they haven't been imported into the terraform state. I was mucking around and noticed this. I thought maybe we might be constructing the id wrong and that is why it thinks it needs to create all these -- that is probably not the case.

Also there seems to be a pretty active fork off of this repo:
https://github.com/hirosassa/terraform-provider-looker
Maybe we pull their commits into ours? Our use theirs?