### PR TITLE
Adding an `Open in DevZero` button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Open in DevZero](https://assets.devzero.io/open-in-devzero.svg)](https://www.devzero.io/dashboard/recipes/new?repo-url=https://github.com/DevotedHealth/terraform-provider-looker)
+
 # Terraform Provider: Looker
 
 This is a terraform provider plugin for managing [Looker](https://www.looker.com/) accounts.


### PR DESCRIPTION
DevZero is a dev environment platform. Using this link, all contributors to this project will be able to use a DevZero environment as their dev workspace.
DevZero supports a free plan that individual contributors to OSS projects can utilize to make their contributions and/or to just test out the project.